### PR TITLE
Correct Wrong Symbol For ZET

### DIFF
--- a/src/CoiniumServ/config/coins/zetacoin.json
+++ b/src/CoiniumServ/config/coins/zetacoin.json
@@ -1,6 +1,6 @@
 {
     "name": "Zetacoin",
-    "symbol": "ZTC",
+    "symbol": "ZET",
     "algorithm": "sha256",
 	"site": "http://zetacoin.cc/",
     "blockExplorer": {


### PR DESCRIPTION
Updated symbol to read 'ZET'