### PR TITLE
Removed erroneous characters from packages.config

### DIFF
--- a/src/CoiniumServ/packages.config
+++ b/src/CoiniumServ/packages.config
@@ -20,5 +20,5 @@
   <package id="Nancy.Viewengines.Razor" version="0.23.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
   <package id="RestSharp" version="104.5.0" targetFramework="net45" />
-  <package id="Serilog" version="1.4.14" targetFramework="net45" />ork="net45" />
+  <package id="Serilog" version="1.4.14" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Didn't affect the project, because the extra characters were ignored. But I thought it better to clean up the file.